### PR TITLE
rework installation of lesson dependencies

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           r-version: 'release'
 
-      - name: Install neeeded packages
+      - name: Install needed packages
         if: steps.check-rmd.outputs.count != 0
         run: |
           install.packages(c('remotes', 'rprojroot', 'renv', 'desc'))

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -92,7 +92,7 @@ jobs:
             eval $cmd
           done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "18.04"), sep = "\n")')
 
-      - name: Install lesson package dependencies
+      - name: Install R lessons package dependencies
         if: steps.check-rmd.outputs.count != 0
         working-directory: lesson
         run: |

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -82,7 +82,7 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
           restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
-      - name: Install system dependencies
+      - name: Install system dependencies for R packages
         if: runner.os == 'Linux' && steps.check-rmd.outputs.count != 0
         working-directory: lesson
         run: |

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           while read -r cmd
           do
-            eval sudo $cmd
+            eval $cmd
           done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "20.04"), sep = "\n")')
 
       - name: Install lesson package dependencies

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -89,7 +89,7 @@ jobs:
           while read -r cmd
           do
             eval $cmd
-          done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "20.04"), sep = "\n")')
+          done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "18.04"), sep = "\n")')
 
       - name: Install lesson package dependencies
         if: steps.check-rmd.outputs.count != 0

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -71,6 +71,7 @@ jobs:
           source('bin/dependencies.R')
           deps <- identify_dependencies()
           create_description(deps)
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
           writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
         shell: Rscript {0}
 

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -58,10 +58,20 @@ jobs:
         with:
           r-version: 'release'
 
-      - name: Install R packages
+      - name: Install neeeded packages
         if: steps.check-rmd.outputs.count != 0
         run: |
-          install.packages('remotes', 'rprojroot', 'renv')
+          install.packages(c('remotes', 'rprojroot', 'renv', 'desc'))
+        shell: Rscript {0}
+
+      - name: Query dependencies
+        if: steps.check-rmd.outputs.count != 0
+        working-directory: lesson
+        run: |
+          source('bin/dependencies.R')
+          deps <- identify_dependencies()
+          create_description(deps)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
         shell: Rscript {0}
 
       - name: Cache R packages
@@ -71,6 +81,23 @@ jobs:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
           restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+
+      - name: Install system dependencies
+        if: runner.os == 'Linux' && steps.check-rmd.outputs.count != 0
+        working-directory: lesson
+        run: |
+          while read -r cmd
+          do
+            eval sudo $cmd
+          done < <(Rscript -e 'cat(remotes::system_requirements("ubuntu", "20.04"), sep = "\n")')
+
+      - name: Install lesson package dependencies
+        if: steps.check-rmd.outputs.count != 0
+        working-directory: lesson
+        run: |
+          remotes::install_deps(dependencies = TRUE)
+          file.remove("DESCRIPTION")
+        shell: Rscript {0}
 
       - name: Determine the proper reference to use
         id: styles-ref

--- a/Makefile
+++ b/Makefile
@@ -119,10 +119,15 @@ HTML_DST = \
   $(patsubst _extras/%.md,${DST}/%/index.html,$(sort $(wildcard _extras/*.md))) \
   ${DST}/license/index.html
 
+## * install-rmd-deps : Install R packages dependencies to build the RMarkdown lesson
+install-rmd-deps:
+	Rscript -e 'source("bin/dependencies.R"); install_dependencies(identify_dependencies())'
+
 ## * lesson-md        : convert Rmarkdown files to markdown
 lesson-md : ${RMD_DST}
 
-_episodes/%.md: _episodes_rmd/%.Rmd
+_episodes/%.md: _episodes_rmd/%.Rmd install-rmd-dependencies
+	mkdir -p _episodes
 	@bin/knit_lessons.sh $< $@
 
 ## * lesson-check     : validate lesson Markdown

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ endif
 
 
 # Controls
-.PHONY : commands clean files
+.PHONY : commands clean files install-rmd-deps
 
 # Default target
 .DEFAULT_GOAL := commands

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ install-rmd-deps:
 lesson-md : ${RMD_DST}
 
 _episodes/%.md: _episodes_rmd/%.Rmd install-rmd-dependencies
-	mkdir -p _episodes
+	@mkdir -p _episodes
 	@bin/knit_lessons.sh $< $@
 
 ## * lesson-check     : validate lesson Markdown

--- a/bin/dependencies.R
+++ b/bin/dependencies.R
@@ -1,0 +1,68 @@
+find_root <- function() {
+  if (!requireNamespace("rprojroot", quietly = TRUE)) {
+    install.packages("rprojroot", lib = lib, repos = repos)
+  }
+
+  cfg  <- rprojroot::has_file_pattern("^_config.y*ml$")
+  root <- rprojroot::find_root(cfg)
+
+  root
+}
+
+identify_dependencies <- function(lib = NULL, repos = getOption("repos")) {
+
+  if (is.null(lib)) {
+    lib <- .libPaths()
+  }
+
+  if (!requireNamespace("renv", quietly = TRUE)) {
+    install.packages("renv", lib = lib, repos = repos)
+  }
+
+  root <- find_root()
+
+  required_pkgs <- unique(c(
+    ## Packages for episodes
+    renv::dependencies(file.path(root, "_episodes_rmd"), progress = FALSE, error = "ignore")$Package,
+    ## Packages for tools
+    renv::dependencies(file.path(root, "bin"), progress = FALSE, error = "ignore")$Package
+  ))
+
+  required_pkgs
+}
+
+install_dependencies <- function(required_pkgs,
+                                 lib = NULL, repos = getOption("repos"),
+                                 update = FALSE, ...) {
+
+  if (missing(lib))  {
+    lib <- .libPaths()
+  }
+
+  missing_pkgs <- setdiff(required_pkgs, rownames(installed.packages()))
+
+  if (length(missing_pkgs)) {
+    message("Installing missing required packages: ",
+      paste(missing_pkgs, collapse=", "))
+    install.packages(missing_pkgs, lib = lib, repos = repos)
+  }
+
+  if (update) {
+    update.packages(
+      lib.loc = lib, repos = repos,
+      ask = FALSE, checkBuilt = TRUE, ...
+    )
+  }
+
+  if (require("knitr") && packageVersion("knitr") < '1.9.19') {
+    stop("knitr must be version 1.9.20 or higher")
+  }
+
+}
+
+create_description <- function(required_pkgs) {
+  require("desc")
+  d <- description$new("!new")
+  lapply(required_pkgs, function(x) d$set_dep(x))
+  d$write("DESCRIPTION")
+}

--- a/bin/generate_md_episodes.R
+++ b/bin/generate_md_episodes.R
@@ -1,34 +1,5 @@
 generate_md_episodes <- function() {
 
-  if (!requireNamespace("renv", quietly = TRUE)) {
-    install.packages("renv", repos = c(CRAN = "https://cloud.r-project.org/"))
-  }
-
-  if (!requireNamespace("rprojroot", quietly = TRUE)) {
-    install.packages("rprojroot", repos = c(CRAN = "https://cloud.r-project.org/"))
-  }
-
-  cfg  <- rprojroot::has_file_pattern("^_config.y*ml$")
-  root <- rprojroot::find_root(cfg)
-
-  required_pkgs <- unique(c(
-    ## Packages for episodes
-    renv::dependencies(file.path(root, "_episodes_rmd"), progress = FALSE, error = "ignore")$Package,
-    ## Pacakges for tools
-    renv::dependencies(file.path(root, "bin"), progress = FALSE, error = "ignore")$Package
-  ))
-
-  missing_pkgs <- setdiff(required_pkgs, rownames(installed.packages()))
-
-  if (length(missing_pkgs)) {
-    message("Installing missing required packages: ",
-            paste(missing_pkgs, collapse=", "))
-    install.packages(missing_pkgs)
-  }
-
-  if (require("knitr") && packageVersion("knitr") < '1.9.19')
-    stop("knitr must be version 1.9.20 or higher")
-
   ## get the Rmd file to process from the command line, and generate the path
   ## for their respective outputs
   args  <- commandArgs(trailingOnly = TRUE)


### PR DESCRIPTION
I reworked the steps to install the dependencies and the caching. I haven't tested everything but locally it seems to be OK. 

In short, I'm re-using steps developed for testing R packages with GitHub actions (from here: https://github.com/r-lib/actions/blob/master/examples/check-standard.yaml). A lot of the tooling assumes that we are dealing with R packages and our lessons don't adhere to the assumptions. I work around this by creating temporarily a DESCRIPTION file (that are expected by the tooling to figure dependencies) that list the packages that the lessons need. In the process, I've reworked the Makefile so almost the same code can be used for dealing with dependencies locally and on GitHub Actions.